### PR TITLE
Bug 3: Add leading zeros to iso date format

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -3,6 +3,7 @@ const today = new Date();
 const tomorrow = new Date(today.getTime() + dayInMS);
 const yesterday = new Date(today.getTime() - dayInMS);
 const isDate = (date) => typeof date.getMonth === "function";
+const zeroPad = (num) => String(num).padStart(2, "0");
 const date2ISO = (date) => date.toISOString().split("T")[0];
 const date2Local = (date) => date.toLocaleDateString("fi");
 const date2LocalShortMonth = (date) => date.toLocaleDateString("fi", { month: "short" });
@@ -75,7 +76,7 @@ const string2ISO = (string) => {
         if (date?.toLowerCase() === "end") {
             return `${current.year + Number.parseInt(number)}-12-31`;
         }
-        return `${current.year + Number.parseInt(number)}-${current.month}-${current.day}`;
+        return `${current.year + Number.parseInt(number)}-${zeroPad(current.month)}-${zeroPad(current.day)}`;
     }
     if (unit.toLowerCase().startsWith("day")) {
         return dateFromToday(Number.parseInt(number), "ISO");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proto-utils",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proto-utils",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "finnish-ssn": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proto-utils",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "This package provides utilities for prototypes",
   "main": "lib/index.js",
   "scripts": {

--- a/src/date.ts
+++ b/src/date.ts
@@ -4,6 +4,7 @@ const tomorrow = new Date(today.getTime() + dayInMS)
 const yesterday = new Date(today.getTime() - dayInMS)
 
 const isDate = (date: any): boolean => typeof date.getMonth === "function"
+const zeroPad = (num: number): string => String(num).padStart(2, "0")
 const date2ISO = (date: Date): string => date.toISOString().split("T")[0]
 const date2Local = (date: Date): string => date.toLocaleDateString("fi")
 const date2LocalShortMonth = (date: Date): string => date.toLocaleDateString("fi", { month: "short" })
@@ -80,7 +81,7 @@ const string2ISO = (string: string): string => {
     if (date?.toLowerCase() === "end") {
       return `${current.year + Number.parseInt(number)}-12-31`
     }
-    return `${current.year + Number.parseInt(number)}-${current.month}-${current.day}`
+    return `${current.year + Number.parseInt(number)}-${zeroPad(current.month)}-${zeroPad(current.day)}`
   }
   if (unit.toLowerCase().startsWith("day")) {
     return dateFromToday(Number.parseInt(number), "ISO") as string


### PR DESCRIPTION
`string2ISO` uses `current.month` and `current.day`, which return numbers, for example `4`. These are used directly in the `string2ISO` returns, which breaks ISO format, since `4` would be `04` in ISO format.