### PR TITLE
Feature 16 – Months

### DIFF
--- a/lib/date.d.ts
+++ b/lib/date.d.ts
@@ -25,6 +25,7 @@ export declare const date: {
     dayInMS: number;
     isISO: (string: string) => boolean;
     local2ISO: (string: string) => string;
+    months: (locale: string) => string[];
     string2ISO: (string: string) => string;
     string2Local: (string: string) => string;
     today: Date;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,6 +28,7 @@ declare const ProtoUtils: {
         dayInMS: number;
         isISO: (string: string) => boolean;
         local2ISO: (string: string) => string;
+        months: (locale: string) => string[];
         string2ISO: (string: string) => string;
         string2Local: (string: string) => string;
         today: Date;

--- a/lib/index.esm.js
+++ b/lib/index.esm.js
@@ -260,6 +260,10 @@ var string2ISO = (string) => {
   return "";
 };
 var string2Local = (string) => ISO2Local(string2ISO(string));
+var months = (locale) => Array.from(
+  { length: 12 },
+  (_, index) => new Intl.DateTimeFormat(locale, { month: "long" }).format(new Date(2e3, index, 1)).replace(/^\w/, (c) => c.toUpperCase())
+);
 var date = {
   ISO,
   ISO2Local,
@@ -276,6 +280,7 @@ var date = {
   dayInMS,
   isISO,
   local2ISO,
+  months,
   string2ISO,
   string2Local,
   today,

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,6 +272,10 @@ var string2ISO = (string) => {
   return "";
 };
 var string2Local = (string) => ISO2Local(string2ISO(string));
+var months = (locale) => Array.from(
+  { length: 12 },
+  (_, index) => new Intl.DateTimeFormat(locale, { month: "long" }).format(new Date(2e3, index, 1)).replace(/^\w/, (c) => c.toUpperCase())
+);
 var date = {
   ISO,
   ISO2Local,
@@ -288,6 +292,7 @@ var date = {
   dayInMS,
   isISO,
   local2ISO,
+  months,
   string2ISO,
   string2Local,
   today,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proto-utils",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "This package provides utilities for prototypes",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/date.ts
+++ b/src/date.ts
@@ -95,6 +95,13 @@ const string2ISO = (string: string): string => {
 }
 const string2Local = (string: string) => ISO2Local(string2ISO(string))
 
+const months = (locale: string): string[] =>
+  Array.from({ length: 12 }, (_, index) =>
+    new Intl.DateTimeFormat(locale, { month: "long" })
+      .format(new Date(2000, index, 1))
+      .replace(/^\w/, c => c.toUpperCase())
+  )
+
 export const date = {
   ISO,
   ISO2Local,
@@ -111,6 +118,7 @@ export const date = {
   dayInMS,
   isISO,
   local2ISO,
+  months,
   string2ISO,
   string2Local,
   today,

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest"
+import ProtoUtils from "../src/index"
+
+describe("date.months", () => {
+  it("returns 12 months", () => {
+    expect(ProtoUtils.date.months("en")).toHaveLength(12)
+  })
+
+  it("returns Finnish month names capitalized", () => {
+    const result = ProtoUtils.date.months("fi")
+    expect(result[0]).toBe("Tammikuu")
+    expect(result[1]).toBe("Helmikuu")
+    expect(result[11]).toBe("Joulukuu")
+  })
+
+  it("returns Swedish month names capitalized", () => {
+    const result = ProtoUtils.date.months("sv")
+    expect(result[0]).toBe("Januari")
+    expect(result[1]).toBe("Februari")
+    expect(result[11]).toBe("December")
+  })
+
+  it("returns English month names capitalized", () => {
+    const result = ProtoUtils.date.months("en")
+    expect(result[0]).toBe("January")
+    expect(result[6]).toBe("July")
+    expect(result[11]).toBe("December")
+  })
+
+  it("returns plain strings", () => {
+    const result = ProtoUtils.date.months("en")
+    result.forEach(month => expect(typeof month).toBe("string"))
+  })
+})


### PR DESCRIPTION
A method to list all month names in order, for example:

```ts
const months = ProtoUtils.date.months("fi")

// Output:
// ["Tammikuu", "Helmikuu", "Maaliskuu"...]

```